### PR TITLE
Automatic update of Microsoft.CodeAnalysis.Analyzers to 2.6.2

### DIFF
--- a/GoldKeeper/GoldKeeper.csproj
+++ b/GoldKeeper/GoldKeeper.csproj
@@ -15,7 +15,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.CodeAnalysis.Analyzers` to `2.6.2` from `1.1.0`
`Microsoft.CodeAnalysis.Analyzers 2.6.2` was published at `2018-09-25T18:49:02Z`, 17 days ago

1 project update:
Updated `GoldKeeper\GoldKeeper.csproj` to `Microsoft.CodeAnalysis.Analyzers` `2.6.2` from `1.1.0`

[Microsoft.CodeAnalysis.Analyzers 2.6.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Analyzers/2.6.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
