### PR TITLE
Automatic update of xunit to 2.4.0

### DIFF
--- a/Tests/GoldKeeperTest/GoldKeeperTest.csproj
+++ b/Tests/GoldKeeperTest/GoldKeeperTest.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a minor update of `xunit` to `2.4.0` from `2.3.1`
`xunit 2.4.0` was published at `2018-07-17T05:02:24Z`, 3 months ago

1 project update:
Updated `Tests\GoldKeeperTest\GoldKeeperTest.csproj` to `xunit` `2.4.0` from `2.3.1`

[xunit 2.4.0 on NuGet.org](https://www.nuget.org/packages/xunit/2.4.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
