### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/GoldKeeper/GoldKeeper.csproj
+++ b/GoldKeeper/GoldKeeper.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/GoldKeeper/GoldKeeper.csproj
+++ b/GoldKeeper/GoldKeeper.csproj
@@ -28,6 +28,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
2 packages were updated: `Microsoft.CodeAnalysis.FxCopAnalyzers`, `Microsoft.VisualStudio.Web.CodeGeneration.Design`
NuKeeper has generated a patch update of `Microsoft.CodeAnalysis.FxCopAnalyzers` to `2.6.2` from `2.6.1`
`Microsoft.CodeAnalysis.FxCopAnalyzers 2.6.2` was published at `2018-09-25T18:49:16Z`, 17 days ago

1 project update:
Updated `GoldKeeper\GoldKeeper.csproj` to `Microsoft.CodeAnalysis.FxCopAnalyzers` `2.6.2` from `2.6.1`

[Microsoft.CodeAnalysis.FxCopAnalyzers 2.6.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/2.6.2)

NuKeeper has generated a patch update of `Microsoft.VisualStudio.Web.CodeGeneration.Design` to `2.1.5` from `2.1.1`
`Microsoft.VisualStudio.Web.CodeGeneration.Design 2.1.5` was published at `2018-10-01T23:08:42Z`, 10 days ago

1 project update:
Updated `GoldKeeper\GoldKeeper.csproj` to `Microsoft.VisualStudio.Web.CodeGeneration.Design` `2.1.5` from `2.1.1`

[Microsoft.VisualStudio.Web.CodeGeneration.Design 2.1.5 on NuGet.org](https://www.nuget.org/packages/Microsoft.VisualStudio.Web.CodeGeneration.Design/2.1.5)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
