### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/GoldKeeper/GoldKeeper.csproj
+++ b/GoldKeeper/GoldKeeper.csproj
@@ -16,7 +16,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/Tests/GoldKeeperTest/GoldKeeperTest.csproj
+++ b/Tests/GoldKeeperTest/GoldKeeperTest.csproj
@@ -9,7 +9,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Tests/GoldKeeperTest/GoldKeeperTest.csproj
+++ b/Tests/GoldKeeperTest/GoldKeeperTest.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
3 packages were updated: `Microsoft.CodeAnalysis.Analyzers`, `xunit`, `xunit.runner.visualstudio`
NuKeeper has generated a major update of `Microsoft.CodeAnalysis.Analyzers` to `2.6.2` from `1.1.0`
`Microsoft.CodeAnalysis.Analyzers 2.6.2` was published at `2018-09-25T18:49:02Z`, 17 days ago

1 project update:
Updated `GoldKeeper\GoldKeeper.csproj` to `Microsoft.CodeAnalysis.Analyzers` `2.6.2` from `1.1.0`

[Microsoft.CodeAnalysis.Analyzers 2.6.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Analyzers/2.6.2)

NuKeeper has generated a minor update of `xunit` to `2.4.0` from `2.3.1`
`xunit 2.4.0` was published at `2018-07-17T05:02:24Z`, 3 months ago

1 project update:
Updated `Tests\GoldKeeperTest\GoldKeeperTest.csproj` to `xunit` `2.4.0` from `2.3.1`

[xunit 2.4.0 on NuGet.org](https://www.nuget.org/packages/xunit/2.4.0)

NuKeeper has generated a minor update of `xunit.runner.visualstudio` to `2.4.0` from `2.3.1`
`xunit.runner.visualstudio 2.4.0` was published at `2018-07-17T05:02:54Z`, 3 months ago

1 project update:
Updated `Tests\GoldKeeperTest\GoldKeeperTest.csproj` to `xunit.runner.visualstudio` `2.4.0` from `2.3.1`

[xunit.runner.visualstudio 2.4.0 on NuGet.org](https://www.nuget.org/packages/xunit.runner.visualstudio/2.4.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
