### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/Tests/DomainTest/DomainTest.csproj
+++ b/Tests/DomainTest/DomainTest.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 

--- a/Tests/DomainTest/DomainTest.csproj
+++ b/Tests/DomainTest/DomainTest.csproj
@@ -9,7 +9,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/GoldKeeperTest/GoldKeeperTest.csproj
+++ b/Tests/GoldKeeperTest/GoldKeeperTest.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Tests/GoldKeeperTest/GoldKeeperTest.csproj
+++ b/Tests/GoldKeeperTest/GoldKeeperTest.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/Tests/GoldKeeperTest/GoldKeeperTest.csproj
+++ b/Tests/GoldKeeperTest/GoldKeeperTest.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.4" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
3 packages were updated in 2 projects:
`xunit`, `xunit.runner.visualstudio`, `Microsoft.AspNetCore.Mvc.Core`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `xunit` to `2.4.1`
2 versions of `xunit` were found in use: `2.3.1`, `2.4.0`
`xunit 2.4.1` was published at `2018-10-29T04:18:23Z`, 7 months ago

2 project updates:
Updated `Tests\DomainTest\DomainTest.csproj` to `xunit` `2.4.1` from `2.3.1`
Updated `Tests\GoldKeeperTest\GoldKeeperTest.csproj` to `xunit` `2.4.1` from `2.4.0`

[xunit 2.4.1 on NuGet.org](https://www.nuget.org/packages/xunit/2.4.1)

NuKeeper has generated a minor update of `xunit.runner.visualstudio` to `2.4.1`
2 versions of `xunit.runner.visualstudio` were found in use: `2.3.1`, `2.4.0`
`xunit.runner.visualstudio 2.4.1` was published at `2018-10-29T04:18:58Z`, 7 months ago

2 project updates:
Updated `Tests\DomainTest\DomainTest.csproj` to `xunit.runner.visualstudio` `2.4.1` from `2.3.1`
Updated `Tests\GoldKeeperTest\GoldKeeperTest.csproj` to `xunit.runner.visualstudio` `2.4.1` from `2.4.0`

[xunit.runner.visualstudio 2.4.1 on NuGet.org](https://www.nuget.org/packages/xunit.runner.visualstudio/2.4.1)

NuKeeper has generated a minor update of `Microsoft.AspNetCore.Mvc.Core` to `2.2.2` from `2.1.1`
`Microsoft.AspNetCore.Mvc.Core 2.2.2` was published at `2019-02-12T16:07:21Z`, 3 months ago

1 project update:
Updated `Tests\GoldKeeperTest\GoldKeeperTest.csproj` to `Microsoft.AspNetCore.Mvc.Core` `2.2.2` from `2.1.1`

[Microsoft.AspNetCore.Mvc.Core 2.2.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Core/2.2.2)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
