### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/Tests/GoldKeeperTest/GoldKeeperTest.csproj
+++ b/Tests/GoldKeeperTest/GoldKeeperTest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.4" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Tests/GoldKeeperTest/GoldKeeperTest.csproj
+++ b/Tests/GoldKeeperTest/GoldKeeperTest.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">

--- a/Tests/GoldKeeperTest/GoldKeeperTest.csproj
+++ b/Tests/GoldKeeperTest/GoldKeeperTest.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.4" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
3 packages were updated in 1 project:
`xunit`, `Microsoft.NET.Test.Sdk`, `Microsoft.AspNetCore.Mvc.Core`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `xunit` to `2.4.1` from `2.4.0`
`xunit 2.4.1` was published at `2018-10-29T04:18:23Z`, 2 years and 1 month ago

1 project update:
Updated `Tests\GoldKeeperTest\GoldKeeperTest.csproj` to `xunit` `2.4.1` from `2.4.0`

[xunit 2.4.1 on NuGet.org](https://www.nuget.org/packages/xunit/2.4.1)

NuKeeper has generated a patch update of `Microsoft.NET.Test.Sdk` to `15.9.2` from `15.9.0`
`Microsoft.NET.Test.Sdk 15.9.2` was published at `2019-05-02T10:14:17Z`, 1 year and 6 months ago
There is also a higher version, `Microsoft.NET.Test.Sdk 16.8.0` published at `2020-11-08T13:22:12Z`, 14 days ago, but this was not applied as only `Minor` version changes are allowed.

1 project update:
Updated `Tests\GoldKeeperTest\GoldKeeperTest.csproj` to `Microsoft.NET.Test.Sdk` `15.9.2` from `15.9.0`

[Microsoft.NET.Test.Sdk 15.9.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/15.9.2)

NuKeeper has generated a minor update of `Microsoft.AspNetCore.Mvc.Core` to `2.2.5` from `2.1.1`
`Microsoft.AspNetCore.Mvc.Core 2.2.5` was published at `2019-05-14T14:49:55Z`, 1 year and 6 months ago

1 project update:
Updated `Tests\GoldKeeperTest\GoldKeeperTest.csproj` to `Microsoft.AspNetCore.Mvc.Core` `2.2.5` from `2.1.1`

[Microsoft.AspNetCore.Mvc.Core 2.2.5 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Core/2.2.5)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
